### PR TITLE
Fix a file issue and apply `elk` instead of `localhost` profile.

### DIFF
--- a/deploy-stack.yml
+++ b/deploy-stack.yml
@@ -1,5 +1,5 @@
-- hosts: localhost
-# remote_user: user
+- hosts: elk
+  # remote_user:
   become: yes
   become_user: root
   roles:

--- a/roles/logstash/files/template/pf-geoip-template.json
+++ b/roles/logstash/files/template/pf-geoip-template.json
@@ -1,63 +1,76 @@
-# 15-others.conf
-filter {
-  if "pf" in [tags] {
-    if [pf_program] =~ /^dhcpd$/ {
-      mutate {
-        add_tag => [ "dhcpd" ]
+{
+  "index_patterns" : "pf-*",
+  "version" : 60001,
+  "settings" : {
+    "index.refresh_interval" : "5s",
+    "number_of_shards": 2
+  },
+  "mappings" : {
+    "dynamic_templates" : [ {
+      "message_field" : {
+        "path_match" : "message",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text",
+          "norms" : false
+        }
       }
-      grok {
-        patterns_dir => ["/etc/logstash/conf.d/patterns"]
-        match => [ "pf_message", "%{DHCPD}"]
+    }, {
+      "string_fields" : {
+        "match" : "*",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text", "norms" : false,
+          "fields" : {
+            "keyword" : { "type": "keyword", "ignore_above": 256 }
+          }
+        }
       }
-    }
-    if [pf_program] =~ /^charon$/ {
-      mutate {
-        add_tag => [ "ipsec" ]
-      }
-    }
-    if [pf_program] =~ /^barnyard2/ {
-      mutate {
-        add_tag => [ "barnyard2" ]
-      }
-    }
-    if [pf_program] =~ /^openvpn/ {
-      mutate {
-        add_tag => [ "openvpn" ]
-      }
-      grok {
-        patterns_dir => ["/etc/logstash/conf.d/patterns"]
-        match => [ "pf_message", "%{OPENVPN}"]
-      }
-    }
-    if [pf_program] =~ /^ntpd/ {
-      mutate {
-        add_tag => [ "ntpd" ]
-      }
-    }
-    if [pf_program] =~ /^php-fpm/ {
-      mutate {
-        add_tag => [ "web_portal" ]
-      }
-      grok {
-        patterns_dir => ["/etc/logstash/conf.d/patterns"]
-        match => [ "pf_message", "%{PF_APP}%{PF_APP_DATA}"]
-      }
-      mutate {
-        lowercase => [ 'pf_ACTION' ]
-      }
-    }
-    if [pf_program] =~ /^unbound/ {
-      mutate {
-        add_tag => [ "unbound" ]
-      }
-      grok {
-        patterns_dir => ["/etc/logstash/conf.d/patterns"]
-        match => [ "pf_message", "%{UNBOUND}"]
-      }
-    }
-    if [pf_program] =~ /^dpinger/ {
-      mutate {
-        add_tag => [ "dpinger" ]
+    } ],
+    "properties" : {
+      "destination": {
+        "properties": {
+          "geo": {
+            "dynamic": true,
+            "properties": {
+              "ip": { "type": "ip" },
+              "location" : { "type" : "geo_point" },
+              "latitude" : { "type" : "half_float" },
+              "longitude" : { "type" : "half_float" }
+            }
+          },
+          "as": {
+            "dynamic": true,
+            "properties": {
+              "ip": { "type": "ip" },
+              "location" : { "type" : "geo_point" },
+              "latitude" : { "type" : "half_float" },
+              "longitude" : { "type" : "half_float" }
+            }
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "dynamic": true,
+            "properties": {
+              "ip": { "type": "ip" },
+              "location" : { "type" : "geo_point" },
+              "latitude" : { "type" : "half_float" },
+              "longitude" : { "type" : "half_float" }
+            }
+          },
+          "as": {
+            "dynamic": true,
+            "properties": {
+              "ip": { "type": "ip" },
+              "location" : { "type" : "geo_point" },
+              "latitude" : { "type" : "half_float" },
+              "longitude" : { "type" : "half_float" }
+            }
+          }
+        }
       }
     }
   }

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -32,7 +32,7 @@
   file:
     path: /etc/logstash/conf.d/patterns
     state: directory
-    mode: '0644'
+    mode: '0744'
 
 - name: Copy pattern file
   copy:
@@ -46,7 +46,7 @@
   file:
     path: /etc/logstash/conf.d/template
     state: directory
-    mode: '0644' 
+    mode: '0744' 
     
 - name: Copy template file
   copy:


### PR DESCRIPTION
## Description

There were three problems I quickly encountered while trying to run this. I thought I'd return the favour by fixing the problems.

> Provide your target IP address in `ansible-pfelk/hosts` under `elk`, the ELK stack will be installed on this target.

1. Currently, this is not the case because `localhost` is specified in `deploy-stack.yml` when it should be `elk`, so that the above statement remains correct.
2. It appears that someone copied the contents of `15-others.conf` into `pf-geoip-template.json`, which is an invalid configuration. I copied the real file from the `pfelk` project.
3. The permissions for the created directories for `logstash` are `0644`, they should be `0744`.

## Fixes

See description. No ticket reference at this time.

- [ x ] Bug fix (non-breaking change which fixes an issue)