### PR TITLE
Change GeoIP db location to /var/lib

### DIFF
--- a/roles/logstash/files/30-geoip.conf
+++ b/roles/logstash/files/30-geoip.conf
@@ -18,12 +18,12 @@ filter {
       if "IP_Private_Source" not in [tags] {
         geoip {
           source => "[source][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[source][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[source][ip]"
           target => "[source][as]"
         }
@@ -46,12 +46,12 @@ filter {
       if "IP_Private_Destination" not in [tags] {
         geoip {
           source => "[destination][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[destination][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[destination][ip]"
           target => "[destination][as]"
         }
@@ -77,12 +77,12 @@ filter {
       if "IP_Private_HAProxy" not in [tags] {
         geoip {
           source => "[client][ip]"
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
           target => "[source][geo]"
         }
         geoip {
           default_database_type => 'ASN'
-#MMR#          database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+#MMR#          database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
           source => "[client][ip]"
           target => "[source][as]"
        }


### PR DESCRIPTION
/var/lib : Variable state information
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html
/usr/share : Architecture-independent data
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html

/var/lib/GeoIP seems to be a location more fitting for the geoip db files

- [x] This change requires a documentation update
